### PR TITLE
How to use a Regular Account (Selfbot) #3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-const Discord = require('discord.js');
-const { Client, MessageEmbed, Intents } = require('discord.js');
-const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS] });
+const Discord = require('discord.js-selfbot-v13');
+const { Client, MessageEmbed } = require('discord.js-selfbot-v13');
+const client = new Client({ checkUpdate: true, });
 require('dotenv').config();
 
 


### PR DESCRIPTION
If you do not want to use a bot for whatever reason it is you can use a regular account (selfbot).

discord.js only allows bot tokens to be connected to the gateway so you are forced to use another package, `discord.js-selfbot-v13`.

# How to install
npm install discord.js-selfbot-v13@latest

# Changes
You will have to change your the classes are destructured and required, replace `discord.js` with `discord.js-selfbot-v13`.